### PR TITLE
Add sed compatibility for OSX and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ apache-activemq-5.14.5
 *.tar.gz
 *.tgz
 *.log*
+*.bak

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ export UIMA_CLASSPATH=/opt/apache-ctakes-4.0.0/lib # you'll want to store this i
 
  i) Use MIST and your own data to create your own model with the generic HIPAA framework. This is outside the scope of this readme and requires understanding Mist and its documentation. Installing that model and fixing the rest of the project to use it would look something like this:
 ```
-sed -i 's/install\ src\/tasks\/SHARP/install\ src\/tasks\/HIPAA/' mist/Dockerfile
-sed -i 's/RUN\ mkdir\ src\/tasks\/SHARP/#RUN\ mkdir\ src\/tasks\/SHARP/'  mist/Dockerfile
-sed -i 's/COPY\ SHARP\ src\/tasks\/SHARP/#COPY\ SHARP\ src\/tasks\/SHARP/' mist/Dockerfile
-sed -i 's/SHARP/HIPAA/' mist/MistAnalysisEngine.java
+sed -i'.bak' 's/install\ src\/tasks\/SHARP/install\ src\/tasks\/HIPAA/' mist/Dockerfile
+sed -i'.bak' 's/RUN\ mkdir\ src\/tasks\/SHARP/#RUN\ mkdir\ src\/tasks\/SHARP/'  mist/Dockerfile
+sed -i'.bak' 's/COPY\ SHARP\ src\/tasks\/SHARP/#COPY\ SHARP\ src\/tasks\/SHARP/' mist/Dockerfile
+sed -i'.bak' 's/SHARP/HIPAA/' mist/MistAnalysisEngine.java
 ```
  ii) Skip de-identification. There are replacement pipelines that do not do de-identification. You will need to rebuild the ctakes-as-pipeline container, pointing it to the descriptor ```desc/nodeidPipeline.xml``` and when you run the CVD, point it to ```remoteNoDeid.xml.```. Adjust the pipeline by running the following:
 ```
-sed -i 's/dictionaryPipeline.xml/nodeidPipeline.xml/' ctakes-as-pipeline/Dockerfile
-sed -i 's/dictionaryPipeline.xml/nodeidPipeline.xml/' ctakes-as-pipeline/desc/deploymentDescriptor.xml
+sed -i'.bak' 's/dictionaryPipeline.xml/nodeidPipeline.xml/' ctakes-as-pipeline/Dockerfile
+sed -i'.bak' 's/dictionaryPipeline.xml/nodeidPipeline.xml/' ctakes-as-pipeline/desc/deploymentDescriptor.xml
 ```
 
 3. Copy env_file_sample.txt to env_file.txt and add your UMLS credentials and IP


### PR DESCRIPTION
Okay, so apparently all `sed`s aren't created equally. The `sed` that comes with Mac is a tad more picky than the GNU based one on Linux (https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux).

This PR will solve the sed issues for newer Macs and will not change the Linux output, which has always worked.

Thanks!