### PR TITLE
Changed name of file to copy in Dockerfile

### DIFF
--- a/ctakes-as-pipeline/Dockerfile
+++ b/ctakes-as-pipeline/Dockerfile
@@ -36,7 +36,7 @@ RUN javac -cp /apache-ctakes-4.0.0/lib/uimaj-core-2.9.0.jar:/apache-ctakes-4.0.0
 RUN javac -cp /apache-ctakes-4.0.0/lib/uimaj-core-2.9.0.jar:/apache-ctakes-4.0.0/lib/ctakes-dictionary-lookup-fast-4.0.0.jar:/apache-ctakes-4.0.0/lib/ctakes-core-4.0.0.jar:/apache-ctakes-4.0.0/lib/ctakes-type-system-4.0.0.jar:/apache-ctakes-4.0.0/lib/uimafit-core-2.2.0.jar IgnorableSectionAnnotator.java
 RUN jar cf consumer.jar DeidAwareTermConsumer.class IgnorableSectionAnnotator.class
 
-COPY lookup-desc-template.xml /apache-ctakes-4.0.0/resources/org/apache/ctakes/dictionary/lookup/fast/sno_rx_16ab.xml
+COPY lookup-descriptor-template.xml /apache-ctakes-4.0.0/resources/org/apache/ctakes/dictionary/lookup/fast/sno_rx_16ab.xml
 ENV UIMA_HOME=/apache-uima-as-2.9.0
 ENV CTAKES_HOME=/apache-ctakes-4.0.0
 ENV UIMA_JVM_OPTS="-Xms2G -Xmx5G"


### PR DESCRIPTION
The `lookup-desc-template.xml` file does not exist, so changed the name to the existing `lookup-descriptor-template.xml` file.